### PR TITLE
poi_marker: Set poi manager init pose to match robot initial pose

### DIFF
--- a/poi_manager/package.xml
+++ b/poi_manager/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>poi_manager</name>
-  <version>0.4.0</version>
+  <version>0.4.1</version>
   <description>The poi_manager package</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag -->


### PR DESCRIPTION
After setting the initial pose, the poi manager stays still in the place where the initial pose was selected instead of moving to the origin.