### PR TITLE
When saving the robot's position, it saves the gps value in params if it is correct.

### DIFF
--- a/poi_manager/src/poi_manager/poi_marker.py
+++ b/poi_manager/src/poi_manager/poi_marker.py
@@ -487,7 +487,7 @@ class PointPathManager(InteractiveMarkerServer):
     self.appendPOI(new_point=new_point, editable=is_editable)
     return new_point
 
-  def save_poi_service(self, name, frame, pose, joints, params = ""):
+  def save_poi_service(self, name, frame, pose, joints={}, params = ""):
     if self.robot_environment == "":
       return False, "No environment selected"
     try:

--- a/poi_manager/src/poi_manager/poi_marker.py
+++ b/poi_manager/src/poi_manager/poi_marker.py
@@ -553,10 +553,8 @@ class PointPathManager(InteractiveMarkerServer):
 
     # get GPS data
     params = ""
-    #Add gps pose in params with the next format: "gps_lat: 40.0, gps_lon: -3.0"
+    #Add gps pose in params with the next format: "gps_lat: 0.1532, gps_lon: -1.3213"
     current_gps_pose = self.getCurrentGPSPose()
-    #Print a message to show the gps position is available
-    rospy.loginfo("%s::addPoiCB: GPS position available: %s" % (self.node_name, current_gps_pose[1]))
     if(current_gps_pose[0]):
       #Print a message to show the gps position
       rospy.loginfo("%s::addPoiCB: GPS position: %f, %f" % (self.node_name, current_gps_pose[2], current_gps_pose[3]))
@@ -861,7 +859,12 @@ class PointPathManager(InteractiveMarkerServer):
 
   def getCurrentGPSPose(self):
     if self.gps_time != None and (rospy.Time.now() - self.gps_time).to_sec() < self.gps_timeout:
-      return True, "GPS position received", self.gps_msg.latitude, self.gps_msg.longitude
+      #Show the gps status are Status_FIX (print)
+      rospy.loginfo("%s::getCurrentGPSPose: GPS position received", self.node_name)
+      if(self.gps_msg.status.status == self.gps_msg.status.STATUS_FIX):
+        return True, "GPS position received", self.gps_msg.latitude, self.gps_msg.longitude
+      else:
+        return False, "Status GPS is not in Fix", None, None
     else:
       return False, "GPS position not received", None, None
 


### PR DESCRIPTION
This pull request introduces GPS integration into the `poi_manager` module, enhancing the functionality by allowing the capture and use of GPS data for points of interest (POIs). Key changes include adding new GPS-related attributes, methods, and modifying existing methods to incorporate GPS data.

The poi_manager node can subscribe to the gps, so if it detects that the gps value is correct, it will add the information in the param value saving both latitude and longitude obtained from the gps.

### GPS Integration:

* Added import for `NavSatFix` from `sensor_msgs.msg` to handle GPS data.
* Introduced new GPS-related attributes (`gps_topic_name`, `gps_time`, `gps_msg`, `gps_timeout`) in the `__init__` method.
* Added `gpsCb` callback method to handle incoming GPS messages.
* Subscribed to the GPS topic in the `rosSetup` method.
* Implemented `getCurrentGPSPose` method to retrieve the current GPS position.

### Enhancements to POI Handling:

* Modified `save_poi_service` method to accept an optional `params` parameter for additional data, such as GPS coordinates. [[1]](diffhunk://#diff-6f97f8cdff4e88cf9a663c358959bd0018d3759a699b68beb05e904dc9dfe364L486-R490) [[2]](diffhunk://#diff-6f97f8cdff4e88cf9a663c358959bd0018d3759a699b68beb05e904dc9dfe364R507-R509)
* Updated `createNewPOIFromRobotPose` method to include GPS data in the POI parameters if available.

### Configuration Updates:

* Added `gps_topic_name` to the configuration dictionary in `ServiceInitialPose2D`.