### PR TITLE
Feat: add default joints values when creating a POI

### DIFF
--- a/poi_manager/src/poi_manager/poi_marker.py
+++ b/poi_manager/src/poi_manager/poi_marker.py
@@ -539,18 +539,9 @@ class PointPathManager(InteractiveMarkerServer):
 
 
     rospy.loginfo("%s::createNewPOI: %s, environment: %s" ,self.node_name, self.add_poi_service_name, self.robot_environment)
-
-    #fill new dictionary with the camera joint states taken from the joint_states_dict
-    poi_joint_dict = {}
-    for i in self.joint_states_dict:
-      if "camera" in i:
-        if "zoom" in i:
-          poi_joint_dict[i] = 1.0
-        else:
-          poi_joint_dict[i] = 0.0
         
     
-    success,msg=self.save_poi_service(new_point.name, new_point.header.frame_id, new_point.pose, poi_joint_dict) 
+    success,msg=self.save_poi_service(new_point.name, new_point.header.frame_id, new_point.pose, self.joint_states_dict) 
      
     if success == False:
         rospy.logerr('%s::createNewPOI: Error calling save_poi_service -> %s', rospy.get_name(), msg)

--- a/poi_manager/src/poi_manager/poi_marker.py
+++ b/poi_manager/src/poi_manager/poi_marker.py
@@ -540,7 +540,18 @@ class PointPathManager(InteractiveMarkerServer):
 
     rospy.loginfo("%s::createNewPOI: %s, environment: %s" ,self.node_name, self.add_poi_service_name, self.robot_environment)
 
-    success,msg=self.save_poi_service(new_point.name,new_point.header.frame_id,new_point.pose)
+    #fill new dictionary with the camera joint states taken from the joint_states_dict
+    poi_joint_dict = {}
+    for i in self.joint_states_dict:
+      if "camera" in i:
+        if "zoom" in i:
+          poi_joint_dict[i] = 1.0
+        else:
+          poi_joint_dict[i] = 0.0
+        
+    
+    success,msg=self.save_poi_service(new_point.name, new_point.header.frame_id, new_point.pose, poi_joint_dict) 
+     
     if success == False:
         rospy.logerr('%s::createNewPOI: Error calling save_poi_service -> %s', rospy.get_name(), msg)
 


### PR DESCRIPTION
This pull request includes a change to the `poi_marker.py` file, specifically in the `createNewPOI` method. The change involves adding a new dictionary to handle camera joint states and passing it to the `save_poi_service` method.

Improvements to handling POI creation:

* [`poi_manager/src/poi_manager/poi_marker.py`](diffhunk://#diff-6f97f8cdff4e88cf9a663c358959bd0018d3759a699b68beb05e904dc9dfe364L543-R554): Added a dictionary (`poi_joint_dict`) to store camera joint states and updated the call to `save_poi_service` to include this dictionary. This ensures that camera joint states are correctly managed when creating a new POI.