### PR TITLE
feat: backup poi when saving

### DIFF
--- a/poi_manager/README.md
+++ b/poi_manager/README.md
@@ -16,13 +16,10 @@ A ROS node to manage the points of interest in a map. It reads a list of tagged 
    
 * ~**folder** (String, default: "/path/to/poi_manager/config"): Folder location of the file that contains the saved POIs.
    
+* ~**yaml_backup_folder** (String, default: "folder/backup"): Folder location of the backups that are created every time we modify the config file.
+
 * ~**publish_markers** (Bool, default: False): Flag to enable the publication of the POIs as [visualization_msgs/MarkerArray](http://docs.ros.org/en/api/visualization_msgs/html/msg/MarkerArray.html)
 
-* ~**marker_topic** (String, default: "markers"): Topic name where markers are published. Only used if publish_markers is true.
-
-* ~**frequency** (Float, default: 0.5): Markers publication frequency. Only used if publish_markers is true.
-
-* ~**frame_id** (String, default: "map"): Frame id at which the markers are published. Only used if publish_markers is true 
 
 ### 1.2 Subscribed Topics
 
@@ -32,12 +29,31 @@ poi_manager does not subscirbe to any topic.
 
 * **poi_manager/markers** (visualization_msgs/MarkerArray):  POIs published as MarkerArray to visualize them in RVIZ
 
+* **poi_manager/state** (robotnik_msgs/State):  The state of the component
+
 ### 1.4 Services
-* **poi_manager/read_pois** ([poi_manager/ReadPOIs](https://github.com/RobotnikAutomation/poi_manager/blob/master/srv/ReadPOIs.srv)): Loads the file where the POIs are stored.
 
-* **poi_manager/update_pois** ([poi_manager/UpdatePOIs](https://github.com/RobotnikAutomation/poi_manager/blob/master/srv/UpdatePOIs.srv)): Saves a list of [poi_manager/LabeledPose](https://github.com/RobotnikAutomation/poi_manager/blob/master/msg/LabeledPose.msg) as POIs in the config file.
+* **poi_manager/add_poi**: Adds a new POI to the list.
 
-* **poi_manager/getPOI** ([robotnik_msgs/GetPOI](https://github.com/RobotnikAutomation/robotnik_msgs/blob/master/srv/GetPOI.srv)): Given a POI name, returns its pose as [geometry_msgs/Pose2D](http://docs.ros.org/en/api/geometry_msgs/html/msg/Pose2D.html).
+* **poi_manager/add_poi_by_params**: Adds a new POI using parameters.
+
+* **poi_manager/add_pois**: Adds multiple POIs at once.
+
+* **poi_manager/delete_environment**: Deletes a specified environment.
+
+* **poi_manager/delete_poi**: Deletes a POI from the list.
+
+* **poi_manager/get_environments**: Retrieves the list of available environments.
+
+* **poi_manager/get_poi**: Retrieves a specific POI.
+
+* **poi_manager/get_poi_list**: Retrieves the list of all POIs.
+
+* **poi_manager/get_poi_params**: Gets the parameters of a specific POI.
+
+* **poi_manager/read_pois**: Loads the file where the POIs are stored.
+
+* **poi_manager/recover_last_backup**: Recovers the last backup of the POIs configuration file.
 
 ### 1.5 Services Called
 
@@ -45,24 +61,119 @@ poi_manager does not call to any service server.
 
 ### 1.6 Action server
 
-poi_manager does not implement any action server.
+No
 
 ### 1.7 Action clients called
 
-poi_manager does not call to any action.
+No
 
 ### 1.8 Required tf Transforms
 
-poi_manager does not require any tf.
+No
 
 ### 1.9 Provided tf Transforms
 
-poi_manager does not provide any tf.
+No 
 
 ### 1.10 Bringup
 
-To launch the node:
+No
 
-```bash
-roslaunch poi_manager poi_manager.launch id_robot:=robot
-```
+## 2 poi_interactive_marker
+
+A ROS node that provides interactive markers for managing POIs in RViz. It allows users to add, move, and delete POIs interactively.
+
+### 2.1 Parameters
+
+* ~**frame_id** (String, default: "map"): Reference frame for the interactive markers.
+
+* ~**marker_scale_x** (Double, default: 0.5): X Scale of the interactive markers.
+
+* ~**marker_scale_y** (Double, default: 0.15): Y Scale of the interactive markers.
+
+* ~**marker_scale_z** (Double, default: 0.15): Z Scale of the interactive markers.
+
+* ~**base_frame_id** (String, default: "robot_base_footprint"): Base frame of the robot.
+* ~**frame_id** (String, default: "robot_map"): Reference frame for the POIs.
+* ~**goto_planner** (String, default: "mb_avoidance/move_base"): Name of the planner used for navigation.
+* ~**use_command_manager_goto** (Bool, default: False): Whether to use the command manager for GOTO actions.
+* ~**use_rms_goto** (Bool, default: False): Whether to use RMS for GOTO actions.
+* ~**rms_manager_action_name** (String, default: "rms/action"): Action name for the RMS manager.
+* ~**command_manager_action_name** (String, default: "command_manager/action"): Action name for the command manager.
+* ~**init_pose_topic_name** (String, default: "initialpose"): Topic name for the initial pose.
+* ~**load_pois_service_name** (String, default: "poi_manager/get_poi_list"): Service name to load the list of POIs.
+* ~**get_poi_service_name** (String, default: "poi_manager/get_poi"): Service name to get a specific POI.
+* ~**add_poi_service_name** (String, default: "poi_manager/add_poi"): Service name to add a new POI.
+* ~**add_poi_params_service_name** (String, default: "poi_manager/add_poi_by_params"): Service name to add a POI by parameters.
+* ~**delete_poi_service_name** (String, default: "poi_manager/delete_poi"): Service name to delete a POI.
+* ~**delete_all_pois_service_name** (String, default: "poi_manager/delete_environment"): Service name to delete all POIs in an environment.
+* ~**rlc_localization_status_topic_name** (String, default: "robot_local_control/LocalizationComponent/status"): Topic name for localization status.
+* ~**command_manager_goto_command** (String, default: "GOTO"): Command string for GOTO actions.
+
+
+### 2.2 Subscribed Topics
+
+* **joint_states** (`sensor_msgs/JointState`)
+* **poi_interactive_marker/feedback** (`visualization_msgs/InteractiveMarkerFeedback`)
+* **rms/action/feedback** (`robot_simple_command_manager_msgs/RobotSimpleCommandActionFeedback`)
+* **rms/action/result** (`robot_simple_command_manager_msgs/RobotSimpleCommandActionResult`)
+* **rms/action/status** (`actionlib_msgs/GoalStatusArray`)
+* **robot_local_control/LocalizationComponent/status** (`robot_local_control_msgs/LocalizationStatus`)
+* **/tf** (`tf2_msgs/TFMessage`)
+* **/tf_static** (`tf2_msgs/TFMessage`)
+
+
+### 2.3 Published Topics
+
+* **initialpose** (`geometry_msgs/PoseWithCovarianceStamped`): Publishes the robot's initial pose.
+* **poi_interactive_marker/state** (`poi_manager_msgs/PoiState`): Publishes the state of the interactive marker.
+* **poi_interactive_marker/update** (`visualization_msgs/InteractiveMarkerUpdate`): Publishes updates to the interactive marker.
+* **poi_interactive_marker/update_full** (`visualization_msgs/InteractiveMarkerInit`): Publishes the full initialization of the interactive marker.
+* **rms/action/cancel** (`actionlib_msgs/GoalID`): Publishes cancel requests for RMS actions.
+* **rms/action/goal** (`robot_simple_command_manager_msgs/RobotSimpleCommandActionGoal`): Publishes goal requests for RMS actions.
+
+
+### 2.4 Services
+
+* **poi_interactive_marker/add_poi**: Adds a new POI via interactive marker.
+* **poi_interactive_marker/add_poi_and_joints**: Adds a new POI along with joint information.
+* **poi_interactive_marker/delete_all_pois**: Deletes all POIs.
+* **poi_interactive_marker/delete_poi**: Deletes a specific POI.
+* **poi_interactive_marker/get_current_pose**: Retrieves the current pose of the robot.
+* **poi_interactive_marker/get_loggers**: Gets the list of available loggers.
+* **poi_interactive_marker/get_poi_list**: Retrieves the list of all POIs.
+* **poi_interactive_marker/get_poi_names_list**: Retrieves the list of POI names.
+* **poi_interactive_marker/save_named_robot_pose**: Saves the robot's current pose with a specified name.
+* **poi_interactive_marker/save_robot_pose**: Saves the robot's current pose.
+* **poi_interactive_marker/set_logger_level**: Sets the logger level.
+* **poi_interactive_marker/stop_goto**: Stops the current GOTO action.
+* **poi_interactive_marker/update_poi_name**: Updates the name of a POI.
+
+
+### 2.5 Services Called
+
+* **poi_manager/add_poi**: To add a new POI to the manager.
+
+* **poi_manager/delete_poi**: To remove a POI from the manager.
+
+* **poi_manager/get_poi_list**: To retrieve the current list of POIs.
+
+### 2.6 Action server
+
+No
+
+### 2.7 Action clients called
+
+No
+
+### 2.8 Required tf Transforms
+
+No
+
+### 2.9 Provided tf Transforms
+
+No
+
+### 2.10 Bringup
+
+No

--- a/poi_manager/package.xml
+++ b/poi_manager/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="2">
   <name>poi_manager</name>
-  <version>0.5.3</version>
+  <version>0.6.0</version>
   <description>The poi_manager package</description>
 
   <!-- One maintainer tag required, multiple allowed, one person per tag -->

--- a/poi_manager/src/poi_manager/poi.py
+++ b/poi_manager/src/poi_manager/poi.py
@@ -16,6 +16,9 @@ from poi_manager_msgs.srv import *
 from geometry_msgs.msg import Pose
 from std_msgs.msg import Empty
 from visualization_msgs.msg import MarkerArray, Marker
+import shutil
+from datetime import datetime
+from std_srvs.srv import Trigger, TriggerResponse
 
 
 
@@ -34,6 +37,7 @@ class PoiManager(RComponent):
         self.filename = rospy.get_param('~filename', 'test')
         self.folder = rospy.get_param('~folder', os.path.join(rospack.get_path('poi_manager'), 'config'))
         self.yaml_path = self.folder + '/' + self.filename+'.yaml'
+        self.yaml_backup_folder = rospy.get_param('~yaml_backup_folder', self.folder + '/backup')
 
         self.publish_markers = rospy.get_param('~publish_markers', False)
 
@@ -53,6 +57,8 @@ class PoiManager(RComponent):
         self.service_get_poi_list = rospy.Service('~get_poi_list', GetPOIs, self.get_poi_list_cb)
         self.service_add_poi = rospy.Service('~add_poi', AddPOI, self.add_poi_cb)
         self.service_add_poi_by_params = rospy.Service('~add_poi_by_params', AddPOI_params, self.add_poi_by_params_cb)
+        self.recover_backup_service = rospy.Service('~recover_last_backup', Trigger, self.recover_last_backup_srv_cb)
+
 
         if self.publish_markers:
             self.marker_array = MarkerArray()
@@ -143,16 +149,6 @@ class PoiManager(RComponent):
         self.read_pois_cb(req)
         self.switch_to_state(State.READY_STATE)
 
-    #def ready_state(self):
-
-        #if self.publish_markers:
-        #    self.update_marker_array()
-
-    def update_yaml(self):
-        yaml_file = open(self.yaml_path, 'w')
-        yaml.dump(self.pose_dict, yaml_file)
-        if self.publish_markers:
-            self.update_marker_array()
 
     def update_marker_array(self):
         marker_array = MarkerArray()
@@ -373,8 +369,14 @@ class PoiManager(RComponent):
             del (self.pose_dict['environments'][req.environment]['points'])
             del (self.pose_dict['environments'][req.environment])
             self.pose_list = []
-            yaml_file = open(self.yaml_path, 'w')
-            yaml.dump(self.pose_dict, yaml_file)
+            
+            ret_save,msg_save = self.save_yaml()
+            if ret_save == False:
+                rospy.logerr('%s::delete_environment_cb: Error saving yaml file -> %s', self._node_name, msg_save)
+                response.success = False
+                response.message = "Error saving yaml file: %s" % msg_save
+                return response
+            
             response.success = True
             response.message = "Environment %s deleted" % (req.environment )
             #print (response.message)
@@ -410,10 +412,17 @@ class PoiManager(RComponent):
                         #self.counter_points_index = self.counter_points_index - 1
                         break
             self.delete_empty_environment(req.environment)
+            
+            ret_save,msg_save = self.save_yaml()
+            if ret_save == False:
+                rospy.logerr('%s::delete_poi_cb: Error saving yaml file -> %s', self._node_name, msg_save)
+                response.success = False
+                response.message = "Error saving yaml file: %s" % msg_save
+                return response
+            
             response.success = True
             response.message = "point %s from environment %s deleted" % (req.name,req.environment )
-            yaml_file = open(self.yaml_path, 'w')
-            yaml.dump(self.pose_dict, yaml_file)
+        
         except Exception as identifier:
             msg = "%s::Error deleting point %s from environment %s. Error msg:%s" % (rospy.get_name(),req.name,req.environment,identifier)
             response.success = False
@@ -466,8 +475,13 @@ class PoiManager(RComponent):
             #print (self.pose_list)
 
             success,msg=self.process_pose_dictionary()
-            yaml_file = open(self.yaml_path, 'w')
-            yaml.dump(self.pose_dict, yaml_file, default_flow_style=False)
+            
+            ret_save,msg_save = self.save_yaml()
+            if ret_save == False:
+                rospy.logerr('%s::add_poi_cb: Error saving yaml file -> %s', self._node_name, msg_save)
+                response.success = False
+                response.message = "Error saving yaml file: %s" % msg_save
+                return response
 
             if success == False:
                 response.success = False
@@ -483,3 +497,120 @@ class PoiManager(RComponent):
             response.message = msg
 
         return response
+
+
+    def save_yaml(self):
+        """
+        Saves the current pose dictionary to a YAML file.
+
+        Attempts to write the contents of `self.pose_dict` to the file specified by `self.yaml_path`
+        in YAML format. If the operation is successful, returns a tuple indicating success and a 
+        success message. If an error occurs during the file operation, logs the error using ROS 
+        logging and returns a tuple indicating failure and the error message.
+
+        Returns:
+            tuple: (bool, str) where the first element indicates success, and the second is a message.
+        """
+        ret, msg = self.backup_yaml()
+        if not ret:
+            rospy.logerr('%s::save_yaml: %s', rospy.get_name(), msg)
+            return False, msg
+
+        try:
+            with open(self.yaml_path, 'w') as yaml_file:
+                yaml.dump(self.pose_dict, yaml_file, default_flow_style=False)
+            return True, "YAML file saved successfully"
+        except Exception as e:
+            rospy.logerr('%s::save_yaml: %s', rospy.get_name(), str(e))
+            return False, "Error saving yaml: %s" % e
+        
+
+    def backup_yaml(self):
+        """
+        Creates a backup of the current YAML file in the specified backup_folder.
+        The backup file will have a prefix based on the current date and time.
+
+        Args:
+            backup_folder (str): The folder where the backup will be stored.
+
+        Returns:
+            tuple: (bool, str) indicating success and a message.
+        """
+
+        if not os.path.exists(self.yaml_path):
+            return False, "YAML file does not exist to backup"
+
+        if not os.path.exists(self.yaml_backup_folder):
+            try:
+                os.makedirs(self.yaml_backup_folder)
+            except Exception as e:
+                return False, "Could not create backup folder: %s" % e
+
+        date_prefix = datetime.now().strftime("%Y%m%d_%H%M%S")
+        base_filename = os.path.basename(self.yaml_path)
+        backup_filename = f"{date_prefix}_{base_filename}"
+        backup_path = os.path.join(self.yaml_backup_folder, backup_filename)
+
+        try:
+            shutil.copy2(self.yaml_path, backup_path)
+            msg = f"Backup created at {backup_path}"
+            rospy.loginfo('%s::backup_yaml: %s', rospy.get_name(), msg)
+            return True, msg
+        except Exception as e:
+            rospy.logerr('%s::backup_yaml: %s', rospy.get_name(), str(e))
+            return False, "Error creating backup: %s" % e
+
+
+    def recover_last_backup(self):
+        """
+        Recovers the most recent backup YAML file from the backup folder and replaces the current YAML file.
+
+        Returns:
+            tuple: (bool, str) indicating success and a message.
+        """
+        try:
+            if not os.path.exists(self.yaml_backup_folder):
+                return False, "Backup folder does not exist"
+
+            backups = [
+                f for f in os.listdir(self.yaml_backup_folder)
+                if os.path.isfile(os.path.join(self.yaml_backup_folder, f)) and f.endswith('.yaml')
+            ]
+            if not backups:
+                return False, "No backup files found"
+
+            # Sort backups by filename (date prefix)
+            backups.sort(reverse=True)
+            last_backup = backups[0]
+            backup_path = os.path.join(self.yaml_backup_folder, last_backup)
+            #
+            # Save current state before recovery
+            ret_save,msg_save = self.save_yaml()
+            if ret_save == False:
+                rospy.logerr('%s::recover_last_backup: Error saving yaml file -> %s', self._node_name, msg_save)    
+                return False, msg_save
+            # Copy the last backup to the original YAML path
+            shutil.copy2(backup_path, self.yaml_path)
+            msg = f"Recovered backup from {backup_path} to {self.yaml_path}"
+            rospy.loginfo('%s::recover_last_backup: %s', rospy.get_name(), msg)
+            
+            ret_parse, msg_parse = self.parse_yaml()
+            
+            if ret_parse == False:
+                rospy.logerr('%s::recover_last_backup: Error parsing yaml file -> %s', self._node_name, msg_parse)
+                return False, msg_parse
+            
+            ret_process, msg_process = self.process_pose_dictionary()
+            if ret_process == False:
+                rospy.logerr('%s::recover_last_backup: Error processing data from yaml file -> %s', self._node_name, msg_process)
+                return False, msg_process
+            return True, "OK, last backup recovered successfully"
+        
+        except Exception as e:
+            rospy.logerr('%s::recover_last_backup: %s', rospy.get_name(), str(e))
+            return False, "Error recovering backup: %s" % e
+        
+
+    def recover_last_backup_srv_cb(self, req):
+        success, message = self.recover_last_backup()
+        return TriggerResponse(success=success, message=message)

--- a/poi_manager/src/poi_manager/poi_marker.py
+++ b/poi_manager/src/poi_manager/poi_marker.py
@@ -331,7 +331,7 @@ class PointPath(InteractiveMarker):
 ## @brief Manages the creation of waypoints and how to send them to Purepursuit
 class PointPathManager(InteractiveMarkerServer):
 
-  def __init__(self, name, args):
+  def __init__(self, args):
     InteractiveMarkerServer.__init__(self, 'poi_interactive_marker')
     self.list_of_points = []
     self.frame_id = args['frame_id']
@@ -351,7 +351,6 @@ class PointPathManager(InteractiveMarkerServer):
     self.delete_poi_service_name = args['delete_poi_service_name']
     self.delete_all_pois_service_name = args['delete_all_pois_service_name']
     self.rlc_localization_status_topic_name = args['rlc_localization_status_topic_name']
-    self.node_name = rospy.get_name()
     self.initial_point = None
 
     self.robot_environment = ""
@@ -442,7 +441,7 @@ class PointPathManager(InteractiveMarkerServer):
 
     resp = self.loadPoisFromServer()
     if resp[0] == False:
-      rospy.logerr("%s::enableManager: %s", self.node_name, resp[1])
+      rospy.logerr("%s::enableManager: %s", rospy.get_name(), resp[1])
 
   def appendPOI(self, new_point, editable = False):
     '''
@@ -561,7 +560,7 @@ class PointPathManager(InteractiveMarkerServer):
     new_point = self.newPOIfromPose(feedback.pose, 'p%d'%(self.counter_points_index), is_editable=False)
 
 
-    rospy.loginfo("%s::createNewPOI: %s, environment: %s" ,self.node_name, self.add_poi_service_name, self.robot_environment)
+    rospy.loginfo("%s::createNewPOI: %s, environment: %s" ,rospy.get_name(), self.add_poi_service_name, self.robot_environment)
         
     
     success,msg=self.save_poi_service(new_point.name, new_point.header.frame_id, new_point.pose, self.joint_states_dict) 
@@ -576,7 +575,7 @@ class PointPathManager(InteractiveMarkerServer):
     current_pose = self.getCurrentPose()
     robot_pose = Pose()
     if(not current_pose[0]):
-      rospy.logerror("%s::getRobotPose: Error: %s" ,self.node_name, current_pose[1])
+      rospy.logerror("%s::getRobotPose: Error: %s" ,rospy.get_name(), current_pose[1])
       return None
     robot_pose.position.x = current_pose[2][0]
     robot_pose.position.y = current_pose[2][1]
@@ -590,12 +589,12 @@ class PointPathManager(InteractiveMarkerServer):
   def createNewPOIFromRobotPose(self, feedback, name=""):
     robot_pose = self.getRobotPose()
     if robot_pose is None:
-      rospy.logerror("%s::createNewPOIFromRobotPose: %s ,environment: Error: creating poi" ,self.node_name, self.add_poi_service_name)
+      rospy.logerror("%s::createNewPOIFromRobotPose: %s ,environment: Error: creating poi" ,rospy.get_name(), self.add_poi_service_name)
       return
     if (name==""):
       name = 'p%d'%(self.counter_points_index)
     new_point = self.newPOIfromPose(robot_pose, name, is_editable=False)
-    rospy.loginfo("%s::createNewPOIFromRobotPose: POI %s added using %s ,environment: %s" ,self.node_name, name, self.add_poi_service_name,self.robot_environment)
+    rospy.loginfo("%s::createNewPOIFromRobotPose: POI %s added using %s ,environment: %s" ,rospy.get_name(), name, self.add_poi_service_name,self.robot_environment)
 
     success,msg=self.save_poi_service(new_point.name,new_point.header.frame_id,new_point.pose, self.joint_states_dict)
 
@@ -850,7 +849,7 @@ class PointPathManager(InteractiveMarkerServer):
 
       self._state.state.state = new_state
       self._state.state.state_description = self.stateToString(self._state.state.state)
-      rospy.loginfo('%s::switchToState: %s',self.node_name,self._state.state.state_description)
+      rospy.loginfo('%s::switchToState: %s',rospy.get_name(),self._state.state.state_description)
 
     return
 
@@ -863,7 +862,7 @@ class PointPathManager(InteractiveMarkerServer):
 
       self._state.action = new_action
 
-      rospy.loginfo('%s::switchToAction: %s',self.node_name, self._state.action)
+      rospy.loginfo('%s::switchToAction: %s',rospy.get_name(), self._state.action)
 
     return
 
@@ -941,7 +940,7 @@ class PointPathManager(InteractiveMarkerServer):
           goal.pose.orientation.z = poi.pose.orientation.z
           goal.pose.orientation.w = poi.pose.orientation.w
           self.planner_client.goTo(goal)
-          rospy.loginfo('%s::goToTagserviceCb: Sending pose', self.node_name)
+          rospy.loginfo('%s::goToTagserviceCb: Sending pose', rospy.get_name())
           self.switchToAction(PoiState.GOTO)
 
           return True,'OK'
@@ -955,7 +954,7 @@ class PointPathManager(InteractiveMarkerServer):
 
   def getPoiListCb(self, request):
     if(request.environment == ""):  
-      rospy.logwarn("%s::getPoiListCb: No environment specified in service call, using active environment '%s'" % (self.node_name, self.robot_environment))
+      rospy.logwarn("%s::getPoiListCb: No environment specified in service call, using active environment '%s'" % (rospy.get_name(), self.robot_environment))
       return self.get_poi_list_client.call(self.robot_environment)
     else:
       return self.get_poi_list_client.call(request.environment) 
@@ -1019,7 +1018,7 @@ class PointPathManager(InteractiveMarkerServer):
 
     if (req.environment != self.robot_environment):
       msg = "Cannot add a POI to an environment (%s) different to active one (%s)" % (req.environment, self.robot_environment)
-      rospy.logerr("%s::addPoiCB: %s" % (self.node_name, msg))
+      rospy.logerr("%s::addPoiCB: %s" % (rospy.get_name(), msg))
       response.success = False
       response.message = msg
       return response       
@@ -1042,7 +1041,7 @@ class PointPathManager(InteractiveMarkerServer):
     response_save = self.save_poi_service(poi.name, poi.frame_id, poi.pose, self.joint_states_dict) # Should I manage if this is correctly done?
     if (response_save[0] == False):
       msg = response_save[1]
-      rospy.logerr("%s::addPoiCB: %s" % (self.node_name, msg))
+      rospy.logerr("%s::addPoiCB: %s" % (rospy.get_name(), msg))
       response.success = response_save[0]
       response.message = msg
       return response
@@ -1051,7 +1050,7 @@ class PointPathManager(InteractiveMarkerServer):
     self.applyChanges()
 
     msg = "POI %s correctly added." % req.name
-    rospy.loginfo("%s::addPoiCB: %s " % (self.node_name, msg))
+    rospy.loginfo("%s::addPoiCB: %s " % (rospy.get_name(), msg))
     response.success = True
     response.message = msg
 
@@ -1062,7 +1061,7 @@ class PointPathManager(InteractiveMarkerServer):
 
     if (req.environment != self.robot_environment):
       msg = "Cannot add a POI to an environment (%s) different to active one (%s)" % (req.environment, self.robot_environment)
-      rospy.logerr("%s::addPoiJointsCB: %s" % (self.node_name, msg))
+      rospy.logerr("%s::addPoiJointsCB: %s" % (rospy.get_name(), msg))
       response.success = False
       response.message = msg
       return response       
@@ -1086,7 +1085,7 @@ class PointPathManager(InteractiveMarkerServer):
     response_save = self.save_poi_service(poi.name, poi.frame_id, poi.pose, poi.joints) # Should I manage if this is correctly done?
     if (response_save[0] == False):
       msg = response_save[1]
-      rospy.logerr("%s::addPoiJointsCB: %s" % (self.node_name, msg))
+      rospy.logerr("%s::addPoiJointsCB: %s" % (rospy.get_name(), msg))
       response.success = response_save[0]
       response.message = msg
       return response
@@ -1095,7 +1094,7 @@ class PointPathManager(InteractiveMarkerServer):
     self.applyChanges()
 
     msg = "POI %s correctly added." % req.name
-    rospy.loginfo("%s::addPoiJointsCB: %s " % (self.node_name, msg))
+    rospy.loginfo("%s::addPoiJointsCB: %s " % (rospy.get_name(), msg))
     response.success = True
     response.message = msg
 
@@ -1117,7 +1116,7 @@ class PointPathManager(InteractiveMarkerServer):
   def serviceDeleteAllPOIs(self, req):
     if(req.data==True):
       try:
-        rospy.loginfo("%s::serviceDeleteAllPOIs %d",self.node_name,len(self.list_of_points))
+        rospy.loginfo("%s::serviceDeleteAllPOIs %d",rospy.get_name(),len(self.list_of_points))
         self.deleteAllPOIs()
         return True,'OK'
       except:
@@ -1130,7 +1129,7 @@ class PointPathManager(InteractiveMarkerServer):
 
     environment = req.environment
     if (environment == ""):
-      rospy.logwarn("%s::updatePoiNameCb: Using current environment '%s'" % (self.node_name, self.robot_environment))
+      rospy.logwarn("%s::updatePoiNameCb: Using current environment '%s'" % (rospy.get_name(), self.robot_environment))
       environment = self.robot_environment
        
        
@@ -1143,7 +1142,7 @@ class PointPathManager(InteractiveMarkerServer):
     if (get_poi_res.success == False):
       msg = "POI with name '%s' does not exists in environment '%s'" % (req.name, environment)
       response.message = msg
-      rospy.logerr("%s::updatePoiNameCb: %s" % (self.node_name, msg))
+      rospy.logerr("%s::updatePoiNameCb: %s" % (rospy.get_name(), msg))
       return response
     
     # DeletePoi
@@ -1161,7 +1160,7 @@ class PointPathManager(InteractiveMarkerServer):
       self.save_poi_service(req.new_name, get_poi_res.p.frame_id, get_poi_res.p.pose, get_poi_res.p.joints) # Should I manage if this is correctly done?
        
     msg = "POI name updated %s -> %s" % (req.name, req.new_name) 
-    rospy.loginfo("%s::updatePoiNameCb: %s" % (self.node_name, msg))
+    rospy.loginfo("%s::updatePoiNameCb: %s" % (rospy.get_name(), msg))
     response.success = True
     response.message = msg
     return response
@@ -1172,7 +1171,7 @@ class PointPathManager(InteractiveMarkerServer):
   # @param req: Srv type SetBool, request- bool
   # @return Srv type SetBool, response- bool sucess, message: string
   def loadPoisFromServer(self):
-      rospy.loginfo("%s::loadPoisFromServer: environment: %s, there were %d pois before loading",self.node_name,self.robot_environment,len(self.list_of_points))
+      rospy.loginfo("%s::loadPoisFromServer: environment: %s, there were %d pois before loading",rospy.get_name(),self.robot_environment,len(self.list_of_points))
       poi_list=[]
 
       if self.robot_environment != '':
@@ -1180,7 +1179,7 @@ class PointPathManager(InteractiveMarkerServer):
           try:
             rospy.wait_for_service(self.load_pois_service_name , timeout = 2)
           except rospy.ROSException as e:
-            rospy.logerr("%s::loadPoisFromServer: %s", self.node_name,e)
+            rospy.logerr("%s::loadPoisFromServer: %s", rospy.get_name(),e)
             return False,'Exception'
           try:
             res = self.get_poi_list_client(self.robot_environment)
@@ -1191,7 +1190,7 @@ class PointPathManager(InteractiveMarkerServer):
               #self.serviceDeleteAllPOIs(req)
               return False,res.message
           except rospy.ServiceException as e:
-            rospy.logerr("%s::loadPoisFromServer: Service call failed: %s",self.node_name,e)
+            rospy.logerr("%s::loadPoisFromServer: Service call failed: %s",rospy.get_name(),e)
             return False,'Exception'
 
       # Deletes the current list of marker points
@@ -1212,7 +1211,7 @@ class PointPathManager(InteractiveMarkerServer):
       self.counter_points_index = max_index + 1
 
       self.applyChanges()
-      rospy.loginfo("%s::loadPoisFromServer: there are %d pois after loading. New point index = %d",self.node_name,len(self.list_of_points),self.counter_points_index)
+      rospy.loginfo("%s::loadPoisFromServer: there are %d pois after loading. New point index = %d",rospy.get_name(),len(self.list_of_points),self.counter_points_index)
       return True,'OK'
 
 
@@ -1268,7 +1267,7 @@ if __name__=="__main__":
       rospy.logerror('%s: %s'%(e, _name))
   #frame_id = args['frame_id']
   #TODO: the object should get the args dict and set them in the init, not this way
-  server = PointPathManager(_name, args)
+  server = PointPathManager(args)
   t_sleep = 0.5
   running = True
   


### PR DESCRIPTION
This pull request introduces significant updates to the `poi_manager` package, including new functionality for managing backups, enhancements to YAML file handling, and the addition of interactive marker capabilities. The most important changes involve the implementation of backup and recovery mechanisms, updates to the service definitions, and the addition of new parameters and topics for the `poi_interactive_marker` node.

### Backup and YAML Handling Enhancements:
* Added `~yaml_backup_folder` parameter to specify the location for YAML backups. [[1]](diffhunk://#diff-9e869a421f19b3e29cd82ed8aea3ca74f135695fca196530d8da694051f121f9L19-L25) [[2]](diffhunk://#diff-1216967c10119ff96a2dc20bee81391f2c69435d211a86eaaf50a2f48f5556beR40)
* Implemented `save_yaml`, `backup_yaml`, and `recover_last_backup` methods to manage YAML file backups and recovery, ensuring data integrity.
* Introduced `recover_last_backup_srv_cb` service callback to allow recovery of the last backup via a ROS service. [[1]](diffhunk://#diff-1216967c10119ff96a2dc20bee81391f2c69435d211a86eaaf50a2f48f5556beR60-R61) [[2]](diffhunk://#diff-1216967c10119ff96a2dc20bee81391f2c69435d211a86eaaf50a2f48f5556beR500-R616)

### Service Updates:
* Added new services for managing POIs, including `recover_last_backup`, `add_poi_by_params`, and others for interactive marker functionality. [[1]](diffhunk://#diff-9e869a421f19b3e29cd82ed8aea3ca74f135695fca196530d8da694051f121f9R32-R179) [[2]](diffhunk://#diff-1216967c10119ff96a2dc20bee81391f2c69435d211a86eaaf50a2f48f5556beR60-R61)

### Interactive Marker Node:
* Introduced a new ROS node `poi_interactive_marker` with parameters for managing POIs interactively in RViz, including marker scaling, navigation planners, and service names.
* Added topics for publishing and subscribing to interactive marker updates, localization status, and robot pose.

### Documentation and Versioning:
* Updated `README.md` to include the new parameters, services, and topics for both `poi_manager` and `poi_interactive_marker` nodes. [[1]](diffhunk://#diff-9e869a421f19b3e29cd82ed8aea3ca74f135695fca196530d8da694051f121f9L19-L25) [[2]](diffhunk://#diff-9e869a421f19b3e29cd82ed8aea3ca74f135695fca196530d8da694051f121f9R32-R179)
* Incremented package version from `0.5.3` to `0.6.0` to reflect the new functionality.