### PR TITLE
fix: elevate poi manager to be able to rotate

### DIFF
--- a/poi_manager/src/poi_manager/poi_marker.py
+++ b/poi_manager/src/poi_manager/poi_marker.py
@@ -211,7 +211,7 @@ class PointPath(InteractiveMarker):
         self.marker.scale.x = marker_scale_x
         self.marker.scale.y = marker_scale_y
         self.marker.scale.z = marker_scale_z
-        #self.marker.pose.position.z = 0.05
+        self.marker.pose.position.z = 0.05
         self.color = color
 
         ##Text of markers


### PR DESCRIPTION
This pull request makes a small change to the `poi_marker.py` file, updating the initialization of marker positions. Specifically, it now sets the `z` coordinate of the marker's position to `0.05` instead of leaving it commented out. This ensures that all markers are consistently placed at the correct height in the visualization.

* Set `self.marker.pose.position.z` to `0.05` in the `__init__` method of `poi_marker.py` to standardize marker height.